### PR TITLE
chore: upgrade to react-email 6

### DIFF
--- a/apps/next-app/actions/send-email.tsx
+++ b/apps/next-app/actions/send-email.tsx
@@ -1,7 +1,7 @@
 'use server'
 
 import { Resend } from "resend"
-import { render } from "@react-email/render";
+import { render } from "react-email";
 
 import { CodepenChallengesEmail } from '@my-repo/transactional/emails/CodepenChallengesEmail';
  

--- a/apps/next-app/package.json
+++ b/apps/next-app/package.json
@@ -11,11 +11,10 @@
   "dependencies": {
     "@my-repo/components": "workspace:*",
     "@my-repo/transactional": "workspace:*",
-    "@react-email/components": "^1.0.0",
-    "@react-email/render": "2.0.0",
     "next": "15.3.5",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
+    "react-email": "^6.0.0",
     "resend": "^6.0.0"
   },
   "devDependencies": {

--- a/apps/next-app/package.json
+++ b/apps/next-app/package.json
@@ -14,7 +14,7 @@
     "next": "15.3.5",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
-    "react-email": "^6.0.0",
+    "react-email": "6.0.0",
     "resend": "^6.0.0"
   },
   "devDependencies": {

--- a/packages/transactional/emails/CodepenChallengesEmail.tsx
+++ b/packages/transactional/emails/CodepenChallengesEmail.tsx
@@ -12,7 +12,7 @@ import {
   Section,
   Text,
   Row,
-} from "@react-email/components";
+} from "react-email";
 import * as React from "react";
 
 import { Wrapper } from "@my-repo/components";

--- a/packages/transactional/package.json
+++ b/packages/transactional/package.json
@@ -6,7 +6,7 @@
   },
   "dependencies": {
     "@my-repo/components": "workspace:*",
-    "@react-email/ui": "^6.0.0",
+    "@react-email/ui": "6.0.0",
     "react": "^19.0.0",
     "react-email": "6.0.0"
   },

--- a/packages/transactional/package.json
+++ b/packages/transactional/package.json
@@ -6,9 +6,9 @@
   },
   "dependencies": {
     "@my-repo/components": "workspace:*",
-    "@react-email/components": "1.0.1",
+    "@react-email/ui": "^6.0.0",
     "react": "^19.0.0",
-    "react-email": "5.0.4"
+    "react-email": "6.0.0"
   },
   "devDependencies": {
     "@types/node": "^24.0.0",


### PR DESCRIPTION
Upgrades to [react-email 6](https://react.email/docs/getting-started/updating-react-email#update-from-react-email-5-0-to-6-0).

### `packages/transactional`
- Remove `@react-email/components`
- Add `react-email@6` and `@react-email/ui@6`
- Update imports in `emails/CodepenChallengesEmail.tsx` from `@react-email/components` to `react-email`

### `apps/next-app`
- Remove `@react-email/components` (unused) and `@react-email/render`
- Add `react-email@6`
- Update `actions/send-email.tsx` to import `render` from `react-email`