### PR TITLE
chore: migrate to pnpm 11

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
   "name": "react-email-pnpm-example",
   "license": "MIT",
-  "packageManager": "pnpm@10.22.0+sha512.bf049efe995b28f527fd2b41ae0474ce29186f7edcb3bf545087bd61fbbebb2bf75362d1307fda09c2d288e1e499787ac12d4fcb617a974718a6051f2eee741c"
+  "packageManager": "pnpm@11.3.0"
 }

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -2,3 +2,5 @@ packages:
   - packages/*
   - packages/transactional/.react-email
   - apps/*
+
+minimumReleaseAge: 1440

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -4,3 +4,7 @@ packages:
   - apps/*
 
 minimumReleaseAge: 1440
+
+allowBuilds:
+  esbuild: true
+  sharp: true

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -3,8 +3,6 @@ packages:
   - packages/transactional/.react-email
   - apps/*
 
-minimumReleaseAge: 1440
-
 allowBuilds:
   esbuild: true
   sharp: true


### PR DESCRIPTION
This migrates the project to pnpm 11.

- Bumps the `packageManager` field in `package.json` to `pnpm@11.3.0`.
- Approves dependency build scripts via `allowBuilds` in `pnpm-workspace.yaml` (`esbuild`, `sharp`) so pnpm 11 does not fail CI with `ERR_PNPM_IGNORED_BUILDS`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)